### PR TITLE
03-05 업데이트 내역 : 메인페이지 패널 리소스 업데이트 및 하단 상단바 로그인 버튼 누를 시 로그인창 이동 업데이트

### DIFF
--- a/src/main/java/Component/LoginORMypageButton.java
+++ b/src/main/java/Component/LoginORMypageButton.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 import Managers.LoginConfrimManager;
 
 import java.awt.*;
+import java.io.IOException;
 
 public class LoginORMypageButton extends JPanel {
     private JButton loginButton, mypageButton;
@@ -32,7 +33,13 @@ public class LoginORMypageButton extends JPanel {
     public void addLoginButton() {
     	//비로그인 상태: 로그인 버튼 추가
         loginButton = new JButton("로그인");
-        loginButton.addActionListener(e -> openPage.openLoginPage());
+        loginButton.addActionListener(e -> {
+			try {
+				openPage.openLoginPage();
+			} catch (IOException e1) {
+				e1.printStackTrace();
+			}
+		});
         add(loginButton);
     }
    

--- a/src/main/java/Managers/DataManagers.java
+++ b/src/main/java/Managers/DataManagers.java
@@ -25,12 +25,16 @@ public class DataManagers {
         }
         return dataManagers;
     }
-
+    
+    public UserVO getMyUser() {
+		return myUser;
+	}
+    
     public void setMyUser(UserVO myUser) {
         this.myUser = myUser;
     }
 
-    public ImageIcon getIcon(String iconName, String iconPath) {
+	public ImageIcon getIcon(String iconName, String iconPath) {
         if(!isLoadedIcon(iconName))
             setLoadedIcon(iconName, iconPath);
 

--- a/src/main/java/Panel/BottomNavBar.java
+++ b/src/main/java/Panel/BottomNavBar.java
@@ -2,6 +2,7 @@ package Panel;
 
 import java.awt.Color;
 import java.awt.Insets;
+import java.io.IOException;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -27,13 +28,13 @@ public class BottomNavBar extends JPanel {
 
 		// 네비게이션 버튼 추가 매개 변수 전달
 		// 출력할 버튼 이름 + x,y좌표 + 크기 + 현재 페이지 + 페이지 이동 메소드 명
-		add(createNavButton("main", startX, 5, buttonSize, "home", "openHomePage"));
-		add(createNavButton("rank", startX + gap, 5, buttonSize, "ranking", "openRankingPage"));
-		add(createNavButton("search", startX + gap * 2, 5, buttonSize, "search", "openSearchPage"));
-		add(createNavButton("myPage", startX + gap * 3, 5, buttonSize, "mypage", "openMyPage"));
+		add(createNavButton("main", startX, 5, buttonSize, "home"));
+		add(createNavButton("rank", startX + gap, 5, buttonSize, "ranking"));
+		add(createNavButton("search", startX + gap * 2, 5, buttonSize, "search"));
+		add(createNavButton("myPage", startX + gap * 3, 5, buttonSize, "mypage"));
 	}
 
-	private JButton createNavButton(String baseName, int x, int y, int size, String pageName, String action) {
+	private JButton createNavButton(String baseName, int x, int y, int size, String pageName) {
 		boolean isActive = currentPage.equals(pageName); // 현재 페이지 여부 확인
 
 		// 버튼 활/비활성화 처리 ex) main + MenuON/MenuOff
@@ -52,32 +53,35 @@ public class BottomNavBar extends JPanel {
 
 		// mypage버튼 눌렀을 때 예외처리 마이테이지 이동 or 로그인 창 이동
 		Navbutton.addActionListener(e -> {
-			if (action.equals("openMyPage")) {
-				if (LoginConfrimManager.loginConfrim("ABC", "123")) { // 로그인 확인 id,pw
+			if (pageName.equals("mypage")) {
+				if (LoginConfrimManager.loginConfrim("DDD", "DDD")) { // 로그인 확인 id,pw 지금 안써서 false 처리
 					// 존재하는 계정이면 마이페이지
 					openPage.openMyPage();
 				} else {
 					// 존재하지 않는 계정이면 마이페이지
-					openPage.openLoginPage();
+					try {
+						openPage.openLoginPage();
+					} catch (IOException e1) {
+						e1.printStackTrace();
+					}
 				}
 			} else {
 				// 매소드에 openpage메소드 명 전달
-				invokeOpenPageMethod(action);
+				try {
+					openPage.navigateToPage(pageName);
+				} catch (IOException e1) {
+					e1.printStackTrace();
+				}
 			}
 		});
 
 		return Navbutton;
-
-	}
-
-	// 버튼 눌렀을때 methodName에 해당하는 Openpage메소드 실행
-	private void invokeOpenPageMethod(String methodName) {
-		// invoke사용 시 접근할 수 없는 메서드를 실행시도 할 수 있기때문에 예외처리
-		try {
-			// 해당 메서드를 실행함
-			OpenPage.class.getMethod(methodName).invoke(openPage);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
 	}
 }
+/*
+ * //버튼 눌렀을때 methodName에 해당하는 Openpage메소드 실행 private void
+ * invokeOpenPageMethod(String methodName) { //invoke사용 시 접근할 수 없는 메서드를 실행시도 할 수
+ * 있기때문에 예외처리 try { //해당 메서드를 실행함
+ * OpenPage.class.getMethod(methodName).invoke(openPage); } catch (Exception e)
+ * { e.printStackTrace(); } }
+ */

--- a/src/main/java/Panel/MainPagePanel.java
+++ b/src/main/java/Panel/MainPagePanel.java
@@ -8,7 +8,6 @@ import java.awt.Insets;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingConstants;
@@ -53,22 +52,22 @@ public class MainPagePanel extends JPanel {
 
 		add(mainPageScroll);
 
-		// 큰 추천 컨텐츠 라벨 추가
-		JLabel bigLabel = bigRecommendContentLabel();
-		bigLabel.setBounds(150, 10, 282, 400); // 큰 패널 위치 크기 컨트롤
-		contentPanel.add(bigLabel);
+		// 큰 추천 컨텐츠 패널 추가
+		JLabel bigPanel = bigRecommendContentLabel();
+		bigPanel.setBounds(150, 10, 282, 400); // 큰 패널 위치 크기 컨트롤
+		contentPanel.add(bigPanel);
 
 		// 작은 추천 컨텐츠 제목 TEXT
-		JLabel smallLabelTitle = new JLabel("오늘의 추천 컨텐츠", SwingConstants.LEFT);
-		smallLabelTitle.setBounds(16, 495, 250, 40); // 제목 위치 설정
-		smallLabelTitle.setForeground(new Color(0x78DBA6));
-		smallLabelTitle.setFont(DataManagers.getInstance().getFont("bold", 20));
-		contentPanel.add(smallLabelTitle);
+		JLabel smallPanelTitle = new JLabel("오늘의 추천 컨텐츠", SwingConstants.LEFT);
+		smallPanelTitle.setBounds(16, 495, 250, 40); // 제목 위치 설정
+		smallPanelTitle.setForeground(new Color(0x78DBA6));
+		smallPanelTitle.setFont(DataManagers.getInstance().getFont("bold", 20));
+		contentPanel.add(smallPanelTitle);
 
-		// 작은 추천 컨텐츠 라벨 추가
-		JLabel smallLabel = smallRecommendContentLabel();
-		smallLabel.setBounds(15, 537, 550, 288); // 작은 추천 컨텐츠 라벨 위치 크기 컨트롤
-		contentPanel.add(smallLabel);
+		// 작은 추천 컨텐츠 패널 추가
+		JPanel smallPanel = smallRecommendContentPanel();
+		smallPanel.setBounds(15, 537, 550, 232); // 작은 패널 위치 크기 컨트롤
+		contentPanel.add(smallPanel);
 
 		// 검색 바 추가
 		JPanel searchBar = createSearchBar();
@@ -99,7 +98,6 @@ public class MainPagePanel extends JPanel {
 		int labelWidth = 200; // 제목과 장르 라벨 너비 센터 배치에 사용
 
 		int thumbX = (bigLabelWidth - thumbWidth) / 2; // 썸네일 중앙 정렬
-		int thumbY = 10;
 		int labelX = (bigLabelWidth - labelWidth) / 2; // 제목과 장르 라벨 중앙 정렬
 
 		// 썸네일 이미지를 버튼 크기에 맞게 리사이징
@@ -107,9 +105,9 @@ public class MainPagePanel extends JPanel {
 		Image scaledthumbnailImage = thumbnailIcon.getImage().getScaledInstance(thumbWidth, thumbHeight,
 				Image.SCALE_SMOOTH);
 		ImageIcon resizedthumbnailIcon = new ImageIcon(scaledthumbnailImage);
-		
+
 		JButton thumbnailButton = new JButton(resizedthumbnailIcon);
-		thumbnailButton.setBounds(thumbX, thumbY, thumbWidth, thumbHeight);
+		thumbnailButton.setBounds(thumbX, 10, thumbWidth, thumbHeight);
 		thumbnailButton.setBorderPainted(false); // 테두리 없음
 		thumbnailButton.setContentAreaFilled(false); // 버튼 배경색 제거
 		thumbnailButton.setFocusPainted(false); // 클릭 시 테두리 없음
@@ -131,25 +129,36 @@ public class MainPagePanel extends JPanel {
 		JLabel ratingTextLabel = new JLabel(String.valueOf(content.getRating()), SwingConstants.LEFT);
 		ratingTextLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
 		ratingTextLabel.setForeground(new Color(0x78DBA6));
-		
-		int ratingTitleX = ratingX + 30;// ratingX + n 평점 아이콘 기준으로 x값 + 좌측으로 이동
-		ratingTextLabel.setBounds(ratingTitleX, titleStandardY + 5, 50, 30);
+
+		// ratingX + n 평점 아이콘 기준으로 x값 + 좌측으로 이동
+		ratingTextLabel.setBounds(ratingX + 30, titleStandardY + 5, 50, 30);
+
+		// 장르 텍스트가 7글자 초과시 .. 처리
+		String bigGenreText = content.getGenres();
+		if (bigGenreText.length() > 7) {
+			bigGenreText = bigGenreText.substring(0, 7) + "..";
+		}
 
 		// 중앙 하단 (장르 텍스트 데이터)
 		int genreX = labelX;
-		JLabel genreTextLabel = new JLabel(content.getGenres(), SwingConstants.CENTER);
-		genreTextLabel.setFont(DataManagers.getInstance().getFont("regular", 13));
+		JLabel genreTextLabel = new JLabel(bigGenreText, SwingConstants.CENTER);
+		genreTextLabel.setFont(DataManagers.getInstance().getFont("regular", 11));
 		genreTextLabel.setForeground(new Color(0x78DBA6));
 		genreTextLabel.setBounds(genreX, titleStandardY + 4, labelWidth, 35);
 
+		// 장르 라벨 아이콘 리사이징
+		ImageIcon bigGenreLabelIcon = DataManagers.getInstance().getIcon("bigCategory", "main_Page");
+		Image scaledBigGenreLabelImage = bigGenreLabelIcon.getImage().getScaledInstance(72, 23, Image.SCALE_SMOOTH);
+		ImageIcon resizedBigGenreLabelIcon = new ImageIcon(scaledBigGenreLabelImage);
+
 		// 중앙 하단 (장르 이미지 데이터)
-		JLabel genreIconLabel = new JLabel(DataManagers.getInstance().getIcon("bigCategory", "main_Page"));
+		JLabel genreIconLabel = new JLabel(resizedBigGenreLabelIcon);
 		genreIconLabel.setBounds(genreX, titleStandardY, labelWidth, 35);
 
 		// 우측 하단 (찜하기 버튼)
 		int favoriteX = labelX + 203; // 장르 라벨 기준 오른쪽 +
 		JButton favoriteButton = new JButton(DataManagers.getInstance().getIcon("bigWishBtnOff", "main_Page"));
-		favoriteButton.setBounds(favoriteX, 361, 30, 30);
+		favoriteButton.setBounds(favoriteX, 362, 30, 30);
 		favoriteButton.setBorderPainted(false);
 		favoriteButton.setContentAreaFilled(false);
 		favoriteButton.setFocusPainted(false);
@@ -174,16 +183,17 @@ public class MainPagePanel extends JPanel {
 	}
 
 	// 작은 추천 컨텐츠 패널 (4개 가로 배치, setLayout(null) 사용)
-	private JLabel smallRecommendContentLabel() {
+	private JPanel smallRecommendContentPanel() {
 
-		// small패널 -> small라벨로 수정 , contenstBG이미지 설정
-		JLabel smallLabel = new JLabel(DataManagers.getInstance().getIcon("contenstBG", "main_Page"));
+		JPanel smallPanel = new RoundedPanel(20, 20); // 라운드 모서리 적용
 
 		// 변경이 잦을 수 있는 위치,크기는 mainpage쪽으로 이동
+		smallPanel.setLayout(null); // null 레이아웃 유지
+		smallPanel.setBackground(new Color(0xCBCBCB));
 
 		int itemWidth = 150; // 아이템 넓이
 		int margin = 10; // 아이템 간격
-		int y = 20; // 아이템의 기본 Y 좌표
+		int y = -10; // 아이템의 기본 Y 좌표
 
 		int leftPadding = 10; // 좌측 아이템 패널과의 여백 설정
 
@@ -196,14 +206,14 @@ public class MainPagePanel extends JPanel {
 			int x = leftPadding + i * (itemWidth + margin);
 
 			// 컨텐츠 아이템 매개변수 전달
-			createContentItem(smallContent, smallLabel, x, y);
+			createContentItem(smallContent, smallPanel, x, y);
 		}
 
-		return smallLabel;
+		return smallPanel;
 	}
 
 	// 기존 방식 유지: createContentItem()에 JPanel을 반환하지 않음
-	private void createContentItem(TestContentVO content, JLabel smallLabel, int x, int y) {
+	private void createContentItem(TestContentVO content, JPanel smallPanel, int x, int y) {
 
 		int itemWidth = 148; // 개별 아이템이 들어갈 넓이 무조건 thumbWidth,labelWidth 보다 커야함
 		int thumbWidth = 148; // 썸네일 넓이
@@ -214,13 +224,13 @@ public class MainPagePanel extends JPanel {
 
 		// 프레임 이미지를 라벨로 설정
 		ImageIcon smallIcon = DataManagers.getInstance().getIcon("smallContentBG", "main_Page");
-		JLabel smallContentLabel = new JLabel(smallIcon);
+		JLabel smallLabel = new JLabel(smallIcon);
 		smallLabel.setLayout(null); // 내부 요소 배치 가능
-		smallLabel.setBounds(x, y + 15, itemWidth, 250); // 프레임 크기 조정
+		smallLabel.setBounds(x, y, itemWidth, 250); // 프레임 크기 조정
 
 		// 찜하기 버튼 (썸네일 위에 배치)
 		JButton favoriteButton = new JButton(DataManagers.getInstance().getIcon("smallWishBtnOff", "main_Page"));
-		favoriteButton.setBounds(x + thumbX + 110, y + 10, 30, 30);
+		favoriteButton.setBounds(x + thumbX + 120, y + 205, 30, 30);
 		favoriteButton.setBorderPainted(false);
 		favoriteButton.setContentAreaFilled(false);
 		favoriteButton.setFocusPainted(false);
@@ -232,14 +242,18 @@ public class MainPagePanel extends JPanel {
 		});
 
 		// 작은 썸네일 이미지를 버튼 크기에 맞게 리사이징
-		ImageIcon smallThumbnailIcon = new ImageIcon(content.getThumbnailFile());
-		Image scaledSmallThumbnailImage = smallThumbnailIcon.getImage().getScaledInstance(thumbWidth, 181,
-				Image.SCALE_SMOOTH);
-		ImageIcon resizedSmallThumbnailIcon = new ImageIcon(scaledSmallThumbnailImage);
+		/*
+		 * ImageIcon smallThumbnailIcon = new ImageIcon(content.getThumbnailFile());
+		 * Image scaledSmallThumbnailImage =
+		 * smallThumbnailIcon.getImage().getScaledInstance(thumbWidth, 181,
+		 * Image.SCALE_SMOOTH); ImageIcon resizedSmallThumbnailIcon = new
+		 * ImageIcon(scaledSmallThumbnailImage);
+		 */
 
 		// 썸네일 이미지 버튼
-		JButton thumbnail = new JButton(resizedSmallThumbnailIcon);
-		thumbnail.setBounds(x, y, thumbWidth, 181);
+		// JButton thumbnail = new JButton(resizedSmallThumbnailIcon);
+		JButton thumbnail = new JButton(DataManagers.getInstance().getIcon("toystoryPoster", "main_Page"));
+		thumbnail.setBounds(x, y + 20, thumbWidth, 181);
 		thumbnail.setBorderPainted(false);
 		thumbnail.setContentAreaFilled(false);
 		thumbnail.setFocusPainted(false);
@@ -247,45 +261,56 @@ public class MainPagePanel extends JPanel {
 
 		// 제목 라벨
 		JLabel titleLabel = new JLabel(content.getTitle(), SwingConstants.CENTER);
-		titleLabel.setFont(DataManagers.getInstance().getFont("bold", 16));
-		int titleLabelY = y + 182;
-		titleLabel.setBounds(x, titleLabelY, labelWidth, 30);
+		titleLabel.setFont(DataManagers.getInstance().getFont("bold", 13));
+		int titleLabelY = y + 188;
+		titleLabel.setBounds(x, titleLabelY + 3, labelWidth, 30);
+
+		// 장르 텍스트가 7글자 초과시 .. 처리
+		String smallGenreText = content.getGenres();
+		if (smallGenreText.length() > 7) {
+			smallGenreText = smallGenreText.substring(0, 7) + "..";
+		}
 
 		// 장르 텍스트
 		int genreY = titleLabelY + 22; // 타이틀 라벨 기준 y+
-		JLabel genreTextLabel = new JLabel(content.getGenres(), SwingConstants.CENTER);
-		genreTextLabel.setFont(DataManagers.getInstance().getFont("regular", 13));
+		JLabel genreTextLabel = new JLabel(smallGenreText, SwingConstants.CENTER);
+		genreTextLabel.setFont(DataManagers.getInstance().getFont("bold", 7));
 		genreTextLabel.setForeground(new Color(0x78DBA6));
-		genreTextLabel.setBounds(x, genreY + 4, labelWidth, 20);
+		genreTextLabel.setBounds(x, genreY + 2, labelWidth, 20);
+
+		ImageIcon smallGenreLabelIcon = DataManagers.getInstance().getIcon("smallCategory", "main_Page");
+		Image scaledsmallGenreLabelImage = smallGenreLabelIcon.getImage().getScaledInstance(46, 13, Image.SCALE_SMOOTH);
+		ImageIcon resizedsmallGenreLabelIcon = new ImageIcon(scaledsmallGenreLabelImage);
 
 		// 장르 이미지
-		JLabel genreIconLabel = new JLabel(DataManagers.getInstance().getIcon("smallCategory", "main_Page"));
+		JLabel genreIconLabel = new JLabel(resizedsmallGenreLabelIcon);
+
 		int genreIconWidth = 160; // 장르 아이콘 크기
 		int genreIconX = x + (itemWidth - genreIconWidth) / 2; // 장르 이미지 중앙 정렬
 		genreIconLabel.setBounds(genreIconX, genreY, genreIconWidth, 20);
 
 		// 평점 아이콘
-		int ratingY = genreY + 22;// 장르 라벨 아래에 위치
+		int ratingY = genreY; // 목적에 맞게 변수이름 변경
 		JLabel ratingIconLabel = new JLabel(DataManagers.getInstance().getIcon("smallRatingIcon", "main_Page"));
 		int ratingIconWidth = 100; // 별점 아이콘 크기
 		int ratingIconX = x + (itemWidth - ratingIconWidth - 30) / 2; // 별점 아이콘 중앙 정렬
-		ratingIconLabel.setBounds(ratingIconX, ratingY, ratingIconWidth, 20);
+		ratingIconLabel.setBounds(ratingIconX - 47, ratingY, ratingIconWidth, 20);
 
 		// 평점 텍스트
 		JLabel ratingValueLabel = new JLabel(String.valueOf(content.getRating()), SwingConstants.LEFT);
-		ratingValueLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
+		ratingValueLabel.setFont(DataManagers.getInstance().getFont("bold", 8));
 		ratingValueLabel.setForeground(new Color(0x78DBA6));
-		ratingValueLabel.setBounds(ratingIconX + 60, ratingY + 4, 40, 20); // 별점 아이콘 오른쪽 정렬
+		ratingValueLabel.setBounds(ratingIconX + 10, ratingY + 3, 40, 20); // 별점 아이콘 오른쪽 정렬
 
 		// UI 배치
-		smallLabel.add(favoriteButton);
-		smallLabel.add(thumbnail);
-		smallLabel.add(titleLabel);
-		smallLabel.add(genreTextLabel);
-		smallLabel.add(genreIconLabel);
-		smallLabel.add(ratingIconLabel);
-		smallLabel.add(ratingValueLabel);
-		smallLabel.add(smallContentLabel);
+		smallPanel.add(favoriteButton);
+		smallPanel.add(thumbnail);
+		smallPanel.add(titleLabel);
+		smallPanel.add(genreTextLabel);
+		smallPanel.add(genreIconLabel);
+		smallPanel.add(ratingIconLabel);
+		smallPanel.add(ratingValueLabel);
+		smallPanel.add(smallLabel);
 	}
 
 	private JPanel createSearchBar() {

--- a/src/main/java/Panel/MainPagePanel.java
+++ b/src/main/java/Panel/MainPagePanel.java
@@ -134,8 +134,9 @@ public class MainPagePanel extends JPanel {
 		ratingTextLabel.setBounds(ratingX + 30, titleStandardY + 5, 50, 30);
 
 		// 장르 텍스트가 7글자 초과시 .. 처리
+		int overNum = 7;//제한될 글자 수
 		String bigGenreText = content.getGenres();
-		if (bigGenreText.length() > 7) {
+		if (bigGenreText.length() > overNum) {
 			bigGenreText = bigGenreText.substring(0, 7) + "..";
 		}
 
@@ -267,7 +268,8 @@ public class MainPagePanel extends JPanel {
 
 		// 장르 텍스트가 7글자 초과시 .. 처리
 		String smallGenreText = content.getGenres();
-		if (smallGenreText.length() > 7) {
+		int overNum = 7;//초과 제한 될 글자 개수
+		if (smallGenreText.length() > overNum) {
 			smallGenreText = smallGenreText.substring(0, 7) + "..";
 		}
 

--- a/src/main/java/Panel/OpenPage.java
+++ b/src/main/java/Panel/OpenPage.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import javax.swing.JOptionPane;
 
 import Frame.FrameBase;
+import Managers.DBDataManagers;
+import Managers.DataManagers;
 import Managers.LoginConfrimManager;
 
 public class OpenPage {
@@ -17,6 +19,7 @@ public class OpenPage {
 	// 임시 로그인 페이지 이동 확인
 	public void openLoginPage() throws IOException {
 		FrameBase.getInstance().setInnerPanel(new LoginPanel(), "mid");
+		FrameBase.getInstance().setInnerPanel(new BottomNavBar("mypage"), "down");
 	}
 
 	// 임시 홈 페이지 이동 확인
@@ -58,7 +61,7 @@ public class OpenPage {
 			openSearchPage();
 			break;
 		case "mypage":
-			if (LoginConfrimManager.loginConfrim("ddd", "ddd")) { // 무조건 false 로그인으로 이동
+			if (DataManagers.getInstance().getMyUser() != null) { // 무조건 false 로그인으로 이동
 				openMyPage();
 			} else {
 				openLoginPage();

--- a/src/main/java/Panel/OpenPage.java
+++ b/src/main/java/Panel/OpenPage.java
@@ -1,42 +1,69 @@
 package Panel;
 
+import java.io.IOException;
+
 import javax.swing.JOptionPane;
 
+import Frame.FrameBase;
+import Managers.LoginConfrimManager;
+
 public class OpenPage {
-	
-	//임시 마이페이지 이동 확인
-    public void openMyPage() {
-        JOptionPane.showMessageDialog(null,"마이페이지로 이동");
-    }
-    
-    //임시 로그인 페이지 이동 확인
-    public void openLoginPage() {
-        JOptionPane.showMessageDialog(null,"로그인 페이지로 이동");
-    }
-    
-    //임시 홈 페이지 이동 확인
-    public void openHomePage() {
-    	JOptionPane.showMessageDialog(null,"홈페이지로 이동");
-    }
-    
-    //임시 랭킹 페이지 이동 확인
-    public void openRankingPage() {
-    	JOptionPane.showMessageDialog(null,"랭킹 페이지로 이동");
-    }
-    
-    //임시 검색 페이지 이동 확인
-    public void openSearchPage() {
-    	JOptionPane.showMessageDialog(null,"검색 페이지로 이동");
-    }
-    
-    //임시 메인 컨텐츠 세부 페이지 이동 확인
-    public void openMainContentPage() {
-    	JOptionPane.showMessageDialog(null,"메인 컨텐츠 세부 페이지 이동 확인");
-    }
-    
-    //임시 메인 컨텐츠 세부 페이지 이동 확인
-    public void openContentPage(String contentTitle) {
-        JOptionPane.showMessageDialog(null, contentTitle + " 상세 페이지 이동");
-    }
-    
+
+	// 임시 마이페이지 이동 확인
+	public void openMyPage() {
+		JOptionPane.showMessageDialog(null, "마이페이지로 이동");
+	}
+
+	// 임시 로그인 페이지 이동 확인
+	public void openLoginPage() throws IOException {
+		FrameBase.getInstance().setInnerPanel(new LoginPanel(), "mid");
+	}
+
+	// 임시 홈 페이지 이동 확인
+	public void openHomePage() throws IOException {
+		FrameBase.getInstance().setInnerPanel(new MainPagePanel(), "mid");
+		FrameBase.getInstance().setInnerPanel(new BottomNavBar("home"), "down");
+	}
+
+	// 임시 랭킹 페이지 이동 확인
+	public void openRankingPage() {
+		JOptionPane.showMessageDialog(null, "랭킹 페이지로 이동");
+	}
+
+	// 임시 검색 페이지 이동 확인
+	public void openSearchPage() {
+		JOptionPane.showMessageDialog(null, "검색 페이지로 이동");
+	}
+
+	// 임시 메인 컨텐츠 세부 페이지 이동 확인
+	public void openMainContentPage() {
+		JOptionPane.showMessageDialog(null, "메인 컨텐츠 세부 페이지 이동 확인");
+	}
+
+	// 임시 메인 컨텐츠 세부 페이지 이동 확인
+	public void openContentPage(String contentTitle) {
+		JOptionPane.showMessageDialog(null, contentTitle + " 상세 페이지 이동");
+	}
+
+	// 하단 네비를 위한 공통 메서드
+	public void navigateToPage(String pageName) throws IOException {
+		switch (pageName) {
+		case "home":
+			openHomePage();
+			break;
+		case "ranking":
+			openRankingPage();
+			break;
+		case "search":
+			openSearchPage();
+			break;
+		case "mypage":
+			if (LoginConfrimManager.loginConfrim("ddd", "ddd")) { // 무조건 false 로그인으로 이동
+				openMyPage();
+			} else {
+				openLoginPage();
+			}
+			break;
+		}
+	}
 }

--- a/src/main/java/Panel/RoundedPanel.java
+++ b/src/main/java/Panel/RoundedPanel.java
@@ -1,0 +1,34 @@
+package Panel;
+
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+
+import javax.swing.JPanel;
+
+//패널에 라운드 줄 수 있도록 함
+//호출해서 사용
+class RoundedPanel extends JPanel {
+	
+	 private int arcWidth;
+	 private int arcHeight;
+
+	 public RoundedPanel(int arcWidth, int arcHeight) {
+		 	this.arcWidth = arcWidth;
+	        this.arcHeight = arcHeight;
+	        setOpaque(false);//배경 투명 처리
+	 }
+
+	 @Override
+	 protected void paintComponent(Graphics g) {
+		 super.paintComponent(g);
+		 Graphics2D g2 = (Graphics2D) g.create();
+	     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+	     g2.setColor(getBackground());
+	     g2.fillRoundRect(0, 0, getWidth(), getHeight(), arcWidth, arcHeight);
+	     g2.dispose();
+	 }
+	 
+}
+
+

--- a/src/main/java/Panel/TopNavBar.java
+++ b/src/main/java/Panel/TopNavBar.java
@@ -2,6 +2,8 @@ package Panel;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.IOException;
+
 import Managers.DataManagers;
 import Managers.LoginConfrimManager;
 
@@ -14,15 +16,13 @@ public class TopNavBar extends JPanel {
 		setBounds(0, 0, 600, 200); // 패널크기 설정
 
 		createLogoSection();
-
-		// 로그인 확인 ture? false?
-		boolean isLogIn = LoginConfrimManager.loginConfrim("ABC", "123");
-
-		if (isLogIn) {
-			createLogInView();// 로그인 시 마이페이지 구성 호출
-		} else {
-			createLogOutView(); // 비로그인 시 로그인 구성 호출
-		}
+		/*
+		 * // 로그인 확인 ture? false? boolean isLogIn =
+		 * LoginConfrimManager.loginConfrim("ABC", "123");
+		 * 
+		 * if (isLogIn) { createLogInView();// 로그인 시 마이페이지 구성 호출 } else {
+		 */
+		createLogOutView(); // 비로그인 시 로그인 구성 호출
 	}
 
 	// Title 텍스트 + 아이콘
@@ -37,7 +37,13 @@ public class TopNavBar extends JPanel {
 		logoTitleButton.setContentAreaFilled(false);
 		logoTitleButton.setFocusPainted(false);
 		// 클릭 시 홈페이지 이동
-		logoTitleButton.addActionListener(e -> openPage.openHomePage());
+		logoTitleButton.addActionListener(e -> {
+			try {
+				openPage.openHomePage();
+			} catch (IOException e1) {
+				e1.printStackTrace();
+			}
+		});
 
 		// 로고 아이콘
 		ImageIcon logoIcon = DataManagers.getInstance().getIcon("logo", "panel_UP");
@@ -48,54 +54,54 @@ public class TopNavBar extends JPanel {
 		logoButton.setFocusPainted(false);
 
 		// 클릭 시 홈페이지 이동
-		logoButton.addActionListener(e -> openPage.openHomePage());
+		logoButton.addActionListener(e -> {
+			try {
+				openPage.openHomePage();
+			} catch (IOException e1) {
+				e1.printStackTrace();
+			}
+		});
 
 		// UI 추가
 		add(logoTitleButton);
 		add(logoButton);
 	}
 
-	// 로그인 상태일 때 메소드 / 닉네임 + 마이페이지 버튼
-	private void createLogInView() {
-
-		String nickname = "민규12345"; // 닉네임 (임시)
-
-		// 패널 너비 가져오기 (이 값을 사용하여 중앙 정렬)
-		int panelWidth = this.getWidth(); // TopNavBar의 너비
-
-		// 닉네임 라벨 생성
-		JLabel welcomeLabel = new JLabel(nickname + "님 반갑습니다.", SwingConstants.CENTER);
-		welcomeLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
-		welcomeLabel.setForeground(new Color(0x78DBA6)); // 민트색
-
-		// 닉네임 중앙 정렬을 위한 X좌표 계산
-		int labelWidth = 180; // 라벨의 가로 길이 (텍스트 길이에 따라 조절 가능)
-		int labelX = (panelWidth - labelWidth) / 2; // 중앙 정렬 X 위치
-
-		// Y좌표 설정
-		welcomeLabel.setBounds(labelX, 30, labelWidth, 40);
-
-		// 마이페이지 버튼 로그인 버튼 대체
-		ImageIcon myPageIcon = DataManagers.getInstance().getIcon("loginButton", "panel_UP");
-		JButton myPageButton = new JButton(myPageIcon);
-		myPageButton.setBounds(480, 26, 90, 40);
-		myPageButton.setBorderPainted(false);
-		myPageButton.setContentAreaFilled(false);
-		myPageButton.setFocusPainted(false);
-
-		// 버튼 텍스트
-		JLabel myPageTextLabel = new JLabel("마이페이지");
-		myPageTextLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
-		myPageTextLabel.setForeground(Color.WHITE);
-		myPageTextLabel.setBounds(495, 39, 90, 20); // 버튼 아래에 배치
-
-		myPageButton.addActionListener(e -> openPage.openMyPage()); // 마이페이지 이동
-
-		// UI 추가
-		add(myPageTextLabel);
-		add(myPageButton);
-		add(welcomeLabel);
-	}
+	// 로그인 상태일 때 메소드 / 닉네임 + 마이페이지 버튼 나중에 사용
+	/*
+	 * private void createLogInView() {
+	 * 
+	 * String nickname = "민규12345"; // 닉네임 (임시)
+	 * 
+	 * // 패널 너비 가져오기 (이 값을 사용하여 중앙 정렬) int panelWidth = this.getWidth(); //
+	 * TopNavBar의 너비
+	 * 
+	 * // 닉네임 라벨 생성 JLabel welcomeLabel = new JLabel(nickname + "님 반갑습니다.",
+	 * SwingConstants.CENTER);
+	 * welcomeLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
+	 * welcomeLabel.setForeground(new Color(0x78DBA6)); // 민트색
+	 * 
+	 * // 닉네임 중앙 정렬을 위한 X좌표 계산 int labelWidth = 180; // 라벨의 가로 길이 (텍스트 길이에 따라 조절 가능)
+	 * int labelX = (panelWidth - labelWidth) / 2; // 중앙 정렬 X 위치
+	 * 
+	 * // Y좌표 설정 welcomeLabel.setBounds(labelX, 30, labelWidth, 40);
+	 * 
+	 * // 마이페이지 버튼 로그인 버튼 대체 ImageIcon myPageIcon =
+	 * DataManagers.getInstance().getIcon("loginButton", "panel_UP"); JButton
+	 * myPageButton = new JButton(myPageIcon); myPageButton.setBounds(480, 26, 90,
+	 * 40); myPageButton.setBorderPainted(false);
+	 * myPageButton.setContentAreaFilled(false);
+	 * myPageButton.setFocusPainted(false);
+	 * 
+	 * // 버튼 텍스트 JLabel myPageTextLabel = new JLabel("마이페이지");
+	 * myPageTextLabel.setFont(DataManagers.getInstance().getFont("bold", 14));
+	 * myPageTextLabel.setForeground(Color.WHITE); myPageTextLabel.setBounds(495,
+	 * 39, 90, 20); // 버튼 아래에 배치
+	 * 
+	 * myPageButton.addActionListener(e -> openPage.openMyPage()); // 마이페이지 이동
+	 * 
+	 * // UI 추가 add(myPageTextLabel); add(myPageButton); add(welcomeLabel); }
+	 */
 
 	// 로그아웃 상태일 때 / 로그인 버튼만 표시
 	private void createLogOutView() {
@@ -113,7 +119,13 @@ public class TopNavBar extends JPanel {
 		loginTextLabel.setForeground(Color.WHITE);
 		loginTextLabel.setBounds(507, 39, 90, 20); // 버튼 아래에 배치
 
-		loginButton.addActionListener(e -> openPage.openLoginPage()); // 로그인 페이지 이동
+		loginButton.addActionListener(e -> {
+			try {
+				openPage.openLoginPage();
+			} catch (IOException e1) {
+				e1.printStackTrace();
+			}
+		}); // 로그인 페이지 이동
 
 		// UI 추가
 		add(loginTextLabel);

--- a/src/main/java/Start/StartMain.java
+++ b/src/main/java/Start/StartMain.java
@@ -4,6 +4,9 @@ import Component.CustomButton;
 import Data.AppConstants;
 import Frame.FrameBase;
 import Managers.DataManagers;
+import Panel.BottomNavBar;
+import Panel.MainPagePanel;
+import Panel.TopNavBar;
 
 import javax.swing.*;
 import java.awt.*;
@@ -11,16 +14,28 @@ import java.io.File;
 import java.io.IOException;
 
 public class StartMain {
-    public static void main(String[] args) {
-        // FrameBase 생성
+    public static void main(String[] args) throws IOException {
+       
+    	// FrameBase 생성
         FrameBase frameBase = FrameBase.getInstance();
 
-        //Start Panel (재연님 추가해주세요.)
+        //Start Panel
         //Main Panel Load!
+        MainPagePanel mainPagePanel = new MainPagePanel();
+        frameBase.setInnerPanel(mainPagePanel, "mid");
+        
+        //하단 네비 바 시작할 경로 "home"
+        BottomNavBar bottomNavBar = new BottomNavBar("home");
+        frameBase.setInnerPanel(bottomNavBar, "down");
+        
+        //상단 바
+        TopNavBar topNavBar = new TopNavBar();
+        frameBase.setInnerPanel(topNavBar, "up");
 
         //---------------------------------
         //Test 및 사용법 숙지를 위한 테스트 코드임!
         //지울 예정임!
+        /*
         JPanel testPanel = new JPanel();
         testPanel.setLayout(null);
         testPanel.setOpaque(false);
@@ -45,5 +60,6 @@ public class StartMain {
         testPanel.add(fontLabel);
         testPanel.add(customButton);
         frameBase.setInnerPanel(testPanel,"up");
+        */
     }
 }

--- a/src/main/java/TESTDAO/TestContentDAO.java
+++ b/src/main/java/TESTDAO/TestContentDAO.java
@@ -7,45 +7,34 @@ import java.util.Random;
 import TESTVO.TestContentVO;
 
 public class TestContentDAO {
-	//list 내 컨텐츠 정보 vo 할당
+	// list 내 컨텐츠 정보 vo 할당
 	List<TestContentVO> contentList;
-	
-	//TestContentVO 새로운 객체 생성
+
+	// TestContentVO 새로운 객체 생성
 	public TestContentDAO() {
-	  contentList = new ArrayList<TestContentVO>();
-	  testContentData(); 
+		contentList = new ArrayList<TestContentVO>();
+		testContentData();
 	}
-	/*
-	// 컨텐츠 데이터 저장
-	public void testContentData() {
-		contentList.add(new TestContentVO("라라랜드", "뮤지컬,로맨스", 9.0, true, "resources/testimage/라라랜드.png"));
-		contentList.add(new TestContentVO("당신거기있어줄래요", "판타지,드라마", 9.9, true,"resources/testimage/당신거기있어줄래요.png"));
-		contentList.add(new TestContentVO("겨울왕국", "애니메이션,뮤지컬", 10.0, true, "resources/testimage/겨울왕국.png"));
-		contentList.add(new TestContentVO("부산행", "액션,스릴러", 6.0, true, "resources/testimage/부산행.png"));
-		contentList.add(new TestContentVO("스파이더맨", "액션,슈퍼히어로", 8.0, true, "resources/testimage/스파이더맨.png"));
-		contentList.add(new TestContentVO("어벤져스", "액션,슈퍼히어로",7.9, true, "resources/testimage/어벤져스.png"));
-		contentList.add(new TestContentVO("인사이드아웃", "애니메이션,가족",8.0, true, "resources/testimage/인사이드아웃.png"));	
-	}
-	*/
+
 	public void testContentData() {
 		contentList.add(new TestContentVO("라라랜드", "뮤지컬,로맨스", 9.0, true, "resources/main_Page/avergensPoster.png"));
-		contentList.add(new TestContentVO("당신거기있어줄래요", "판타지,드라마", 9.9, true,"resources/main_Page/toystoryPoster.png"));
+		contentList.add(new TestContentVO("당신거기있어줄래요", "판타지,드라마", 9.9, true, "resources/main_Page/toystoryPoster.png"));
 		contentList.add(new TestContentVO("겨울왕국", "애니메이션,뮤지컬", 10.0, true, "resources/main_Page/avergensPoster.png"));
 		contentList.add(new TestContentVO("부산행", "액션,스릴러", 6.0, true, "resources/main_Page/avergensPoster.png"));
 		contentList.add(new TestContentVO("스파이더맨", "액션,슈퍼히어로", 8.0, true, "resources/main_Page/toystoryPoster.png"));
-		contentList.add(new TestContentVO("어벤져스", "액션,슈퍼히어로",7.9, true, "resources/main_Page/toystoryPoster.png"));
-		contentList.add(new TestContentVO("인사이드아웃", "애니메이션,가족",8.0, true, "resources/main_Page/avergensPoster.png"));	
+		contentList.add(new TestContentVO("어벤져스", "액션,슈퍼히어로", 7.9, true, "resources/main_Page/toystoryPoster.png"));
+		contentList.add(new TestContentVO("인사이드아웃", "애니메이션,가족", 8.0, true, "resources/main_Page/avergensPoster.png"));
 	}
-	
-	//전체 컨텐츠 목록 반환
-	 public List<TestContentVO> getAllContents() {
-	        return contentList;
-	    }
-	 
-	 //랜덤 컨텐츠 가져오기
-	 public TestContentVO getRandomContent() {
-	        Random random = new Random();
-	        return contentList.get(random.nextInt(contentList.size()));
-	    }
-	
+
+	// 전체 컨텐츠 목록 반환
+	public List<TestContentVO> getAllContents() {
+		return contentList;
+	}
+
+	// 랜덤 컨텐츠 가져오기
+	public TestContentVO getRandomContent() {
+		Random random = new Random();
+		return contentList.get(random.nextInt(contentList.size()));
+	}
+
 }

--- a/src/main/java/TESTVO/TestContentVO.java
+++ b/src/main/java/TESTVO/TestContentVO.java
@@ -1,24 +1,22 @@
 package TESTVO;
 
-import java.util.List;
-
 public class TestContentVO {
-    private String title; //제목 - 썸네일 불러오기
-    private double rating; //리뷰 평점 - 매서드 활용해서 사용
-    private boolean isFavorite; //찜 여부
-    private String thumbnailFile;//썸네일 이미지 경로
-    private String genres; //장르
-    
-    //데이터 받을 생성자
-    public TestContentVO(String title, String genres, double rating, boolean isFavorite, String thumbnailFile) {
+	private String title; // 제목 - 썸네일 불러오기
+	private double rating; // 리뷰 평점 - 매서드 활용해서 사용
+	private boolean isFavorite; // 찜 여부
+	private String thumbnailFile;// 썸네일 이미지 경로
+	private String genres; // 장르
+
+	// 데이터 받을 생성자
+	public TestContentVO(String title, String genres, double rating, boolean isFavorite, String thumbnailFile) {
 		this.title = title;
 		this.rating = rating;
 		this.isFavorite = isFavorite;
 		this.thumbnailFile = thumbnailFile;
 		this.genres = genres;
 	}
-	
-	//geter seter 생성
+
+	// geter seter 생성
 	public String getTitle() {
 		return title;
 	}
@@ -51,12 +49,11 @@ public class TestContentVO {
 		this.thumbnailFile = thumbnailFile;
 	}
 
-    public String getGenres() {
-        return genres;
-    }
+	public String getGenres() {
+		return genres;
+	}
 
-    public void setGenres(String genres) {
-        this.genres = genres;
-    }
+	public void setGenres(String genres) {
+		this.genres = genres;
+	}
 }
-


### PR DESCRIPTION
1. Panel > BottomNavbar 마이페이지 버튼 누를 시 로그인 페이지 이동(로그인 확인 무조건 false로 임시 변경)
2. Panel > MainPagePanel ui 리소스 Figma에 맞게 재배치
3. Panel > OpenPage 홈, 로그인 페이지 이동 메서드 돌아가게 수정, 하단 네비바 이동시 텍스트 전달로 버튼 활성화, 비활성화하도록 case문 추가
4. Panel > RoundedPanel부활 클래스 호출 시 원하는 패널에 라운드를 줄 수 있게함
5. Panel > 최초 접속 시 무조건 비로그인 상태로 로그인 버튼이 활성화되도록 처리
6. Start > mainpagepanel,하단,상단바 호출 코드 추가
7. DAO > DAO,VO 열맞춤
*로그인 패널의 registerUser 주석해야 로그인 페이지로 이동