### PR TITLE
이미징 관련 업데이트 일부 페이지 버그 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
             <artifactId>imageio-webp</artifactId>
             <version>3.8.1</version>
         </dependency>
+        
+        <dependency>
+    		<groupId>net.coobird</groupId>
+    		<artifactId>thumbnailator</artifactId>
+    		<version>0.4.19</version> <!-- 최신 버전, 필요 시 확인 -->
+		</dependency>
+        
     </dependencies>
 
 </project>

--- a/src/main/java/DAO/ContentDAO.java
+++ b/src/main/java/DAO/ContentDAO.java
@@ -35,19 +35,32 @@ public class ContentDAO {
 			}
 		}
 	}
-
+	
 	// 전체 컨텐츠 목록 반환(중복 제거된 데이터)
 	public List<ItemVO> getAllContents() {
 		return contentList;
 	}
 
 	// 랜덤 컨텐츠 반환
-	public ItemVO getRandomContent() {
-		if (contentList.isEmpty()) {
-			return null; // 남은 컨텐츠 없을 경우 null 반환
-		}
-		Random random = new Random();
-		int index = random.nextInt(contentList.size());
-		return contentList.remove(index); // 뽑은 컨텐츠 삭제 후 반환 다시 뽑힐 수 없게 함
+	public ItemVO getRandomContent(List<Integer> excludeIds) {
+		// 제외되지 않은 리스트 생성
+	    List<ItemVO> filteredList = new ArrayList<>();
+	    for (ItemVO item : contentList) {
+	        if (!excludeIds.contains(item.getId())) {
+	            filteredList.add(item);
+	        }
+	    }
+
+	    // 사용할 수 있는 게 없으면 null
+	    if (filteredList.isEmpty()) {
+	        return null;
+	    }
+
+	    // 랜덤 반환
+	    Random random = new Random();
+	    int index = random.nextInt(filteredList.size());
+	    ItemVO selectedItem = filteredList.get(index);
+	    contentList.remove(selectedItem); // 사용한 데이터 제거 (중복 방지)
+	    return selectedItem;
 	}
 }

--- a/src/main/java/Helper/SmoothLabel.java
+++ b/src/main/java/Helper/SmoothLabel.java
@@ -1,0 +1,22 @@
+package Helper;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SmoothLabel extends JLabel {
+
+    public SmoothLabel(String text) {
+        super(text);
+        setOpaque(false); // 배경 투명
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g.create(); // 복사본
+        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        super.paintComponent(g2);
+        g2.dispose(); // 메모리 누수 방지
+    }
+}

--- a/src/main/java/Managers/DataManagers.java
+++ b/src/main/java/Managers/DataManagers.java
@@ -29,7 +29,7 @@ public class DataManagers {
     //로드된 영화 데이터
     private Map<Integer, ItemVO> items = new HashMap<>();
     //로드된 썸네일 데이터
-    private Map<Integer, ImageIcon> tempThumbnail = new HashMap<>();
+    private Map<String, ImageIcon> tempThumbnail = new HashMap<>();
 
     private UserVO myUser;
 
@@ -54,7 +54,7 @@ public class DataManagers {
         isInitialized = true;
     }
 
-    public Map<Integer, ImageIcon> getTempThumbnail() {
+    public Map<String, ImageIcon> getTempThumbnail() {
         return tempThumbnail;
     }
 
@@ -233,5 +233,10 @@ public class DataManagers {
             }
         }
         return false;
+    }
+    
+    //아이콘 캐시초기화 
+    public void clearIconCache() {
+        this.icons.clear(); // 캐시 초기화
     }
 }

--- a/src/main/java/Panel/ContentsDetailImagePanel.java
+++ b/src/main/java/Panel/ContentsDetailImagePanel.java
@@ -9,6 +9,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -60,11 +61,9 @@ public class ContentsDetailImagePanel extends JPanel {
 		firstPanel.setBorder(null);
 
 		// 이미지 라벨
-		ImageIcon thumbnailIcon = ImageHelper.getResizedImageIconFromUrl(content.getThumbnail(), 222, 271,content.getId());
-		Image scaledthumbnailImage = thumbnailIcon.getImage().getScaledInstance(129, 161, Image.SCALE_SMOOTH);
-		ImageIcon resizedthumbnailIcon = new ImageIcon(scaledthumbnailImage);
+		ImageIcon thumbnailIcon = ImageHelper.getResizedImageIconFromUrl(content.getThumbnail(), 129, 161,content.getId(), false, true);
 
-		JLabel thumbnailPoster = new JLabel(resizedthumbnailIcon);
+		JLabel thumbnailPoster = new JLabel(thumbnailIcon);
 		thumbnailPoster.setLayout(null);
 		thumbnailPoster.setBounds(405, 30, 129, 161);
 
@@ -376,7 +375,9 @@ public class ContentsDetailImagePanel extends JPanel {
 		directorActorMenu.setBounds(297, 75, 120, 30);
 		directorActorMenu.setFont(DataManagers.getInstance().getFont("regular", 17));
 		directorActorMenu.setForeground(Color.decode("#CBCBCB"));
-		JLabel directorActorLabelInfo = new JLabel(content.getDirector() + "/" + content.getActor()[0]);
+		// 감독/출연 라벨 세팅 (배우가 없을 경우 방어 처리)
+		String actorName = (content.getActor() != null && content.getActor().length > 0) ? content.getActor()[0] : "정보 없음";
+		JLabel directorActorLabelInfo = new JLabel(content.getDirector() + " / " + actorName);
 		directorActorLabelInfo.setLayout(null);
 		directorActorLabelInfo.setBounds(402, 75, 161, 30);
 		directorActorLabelInfo.setFont(DataManagers.getInstance().getFont("thin", 16));
@@ -522,7 +523,7 @@ public class ContentsDetailImagePanel extends JPanel {
 
 		// ItemVO의 List<Map<String, String>>구조를 갖고있는 categories를 활용하여
 		List<Map<String, String>> categories = content.getCategory();
-
+		
 		// platform을 기준으로 해당 기준에 만족되는 url만 접속할 수 있는 버튼을 표시해주는 switch/case 구문
 		for (Map<String, String> category : categories) {
 			String platform = category.get("platform");

--- a/src/main/java/Panel/MainPagePanel.java
+++ b/src/main/java/Panel/MainPagePanel.java
@@ -5,6 +5,8 @@ import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.Insets;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -19,6 +21,7 @@ import DAO.FavoriteDAO;
 import Data.AppConstants;
 import Helper.GenericFinder;
 import Helper.ImageHelper;
+import Helper.SmoothLabel;
 import Managers.DBDataManagers;
 import Managers.DataManagers;
 import VO.FavoriteVO;
@@ -125,12 +128,9 @@ public class MainPagePanel extends JPanel {
 		int labelX = (bigLabelWidth - labelWidth) / 2; // 제목과 장르 라벨 중앙 정렬
 
 		// 썸네일 이미지를 버튼 크기에 맞게 리사이징
-		ImageIcon thumbnailIcon = ImageHelper.getResizedImageIconFromUrl(content.getThumbnail(), 222, 271, content.getId());
-		Image scaledthumbnailImage = thumbnailIcon.getImage().getScaledInstance(thumbWidth, thumbHeight,
-				Image.SCALE_SMOOTH);
-		ImageIcon resizedthumbnailIcon = new ImageIcon(scaledthumbnailImage);
+		ImageIcon thumbnailIcon = ImageHelper.getResizedImageIconFromUrl(content.getThumbnail(), 266, 325, content.getId(), true, false);
 
-		JButton thumbnailButton = new JButton(resizedthumbnailIcon);
+		JButton thumbnailButton = new JButton(thumbnailIcon);
 		thumbnailButton.setBounds(thumbX, 10, thumbWidth, thumbHeight);
 		thumbnailButton.setBorderPainted(false); // 테두리 없음
 		thumbnailButton.setContentAreaFilled(false); // 버튼 배경색 제거
@@ -175,7 +175,8 @@ public class MainPagePanel extends JPanel {
 
 		// 중앙 하단 (장르 텍스트 데이터)
 		int genreX = labelX;
-		JLabel genreTextLabel = new JLabel(bigGenreText, SwingConstants.CENTER);
+		SmoothLabel genreTextLabel = new SmoothLabel(bigGenreText);
+		genreTextLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		genreTextLabel.setFont(DataManagers.getInstance().getFont("regular", 11));
 		genreTextLabel.setForeground(Color.decode(AppConstants.UI_POINT_COLOR_HEX));
 		genreTextLabel.setBounds(genreX, titleStandardY + 4, labelWidth, 35);
@@ -300,9 +301,19 @@ public class MainPagePanel extends JPanel {
 		int totalWidth = leftPadding + (itemWidth + margin) * countContent;
 		itemPanel.setPreferredSize(new Dimension(totalWidth, smallPanelHeight)); // 전체 사이즈
 
-		for (int i = 0; i < countContent; i++) { // N개의 컨텐츠 추가
-			item = contentDAO.getRandomContent(); // 랜덤 컨텐츠 가져오기
+		// big에서 가져온 ID 저장
+		int bigContentId = content.getId();
 
+		// small 패널 채우기 (중복 제거하며 가져오기)
+		List<Integer> excludeList = new ArrayList<>();
+		excludeList.add(bigContentId); // 빅 추천 콘텐츠 ID 추가
+		
+		for (int i = 0; i < countContent; i++) { // N개의 컨텐츠 추가
+			item = contentDAO.getRandomContent(excludeList); // 랜덤 컨텐츠 가져오기
+			
+			if (item == null) break; // 남은 컨텐츠 없으면 중단
+			excludeList.add(item.getId()); // 이미 사용한 ID 추가 (혹시 중복 막기 위해)
+			
 			// 각 아이템 x 좌표를 조정하여 가로 정렬
 			int x = leftPadding + i * (itemWidth + margin);
 
@@ -431,7 +442,7 @@ public class MainPagePanel extends JPanel {
 			itemsPanel.add(favoriteButton);
 		}
 
-		JButton thumbnail = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 134, 164, item.getId()));
+		JButton thumbnail = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 134, 164, item.getId(), true, false));
 		thumbnail.setBounds(x, y + 20, thumbWidth, 181);
 		thumbnail.setBorderPainted(false);
 		thumbnail.setContentAreaFilled(false);
@@ -453,7 +464,8 @@ public class MainPagePanel extends JPanel {
 
 		// 장르 텍스트
 		int genreY = titleLabelY + 22; // 타이틀 라벨 기준 y+
-		JLabel genreTextLabel = new JLabel(smallGenreText, SwingConstants.CENTER);
+		SmoothLabel genreTextLabel = new SmoothLabel(smallGenreText);
+		genreTextLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		genreTextLabel.setFont(DataManagers.getInstance().getFont("bold", 7));
 		genreTextLabel.setForeground(Color.decode(AppConstants.UI_POINT_COLOR_HEX));
 		genreTextLabel.setBounds(x, genreY + 2, labelWidth, 20);

--- a/src/main/java/Panel/MyPagePanel.java
+++ b/src/main/java/Panel/MyPagePanel.java
@@ -343,7 +343,7 @@ public class MyPagePanel extends JPanel {
 		rankingLabel.setLayout(null);
 
 		// 썸네일 버튼
-		JButton thumbnailButton = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 79, 99, item.getId()));
+		JButton thumbnailButton = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 79, 99, item.getId(), false, true));
 		thumbnailButton.setBounds(50, 14, 79, 99);
 		thumbnailButton.setBorderPainted(false);
 		thumbnailButton.setContentAreaFilled(false);

--- a/src/main/java/Panel/OpenPage.java
+++ b/src/main/java/Panel/OpenPage.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import javax.swing.JOptionPane;
 
 import Frame.FrameBase;
-
+import Helper.ImageHelper;
 import Managers.DataManagers;
 import VO.ItemVO;
 
@@ -38,12 +38,15 @@ public class OpenPage {
 
 	// 랭킹 페이지 이동 확인
 	public void openRankingPage() throws IOException {
+        DataManagers.getInstance().clearIconCache();//아이콘 캐시 초기화
+		ImageHelper.clearImageCache(); //이미지 캐시 초기화
 		FrameBase.getInstance().setInnerPanel(new RankingPagePanel(), "mid");
 		FrameBase.getInstance().setInnerPanel(new BottomNavBar("ranking"), "down");
 	}
 
 	// 임시 검색 페이지 이동 확인
 	public void openSearchPage() throws IOException {
+		ImageHelper.clearImageCache(); //캐시 초기화
 		FrameBase.getInstance().setInnerPanel(new SearchMainPanel(), "mid");
 		FrameBase.getInstance().setInnerPanel(new BottomNavBar("search"), "down");
 	}
@@ -55,6 +58,8 @@ public class OpenPage {
 
 	// 임시 메인 컨텐츠 세부 페이지 이동 확인
 	public void openContentPage(ItemVO content) {
+		DataManagers.getInstance().clearIconCache();//아이콘 캐시 초기화
+		ImageHelper.clearImageCache(); //이미지 캐시 초기화
 		try {
 			// 클릭한 콘텐츠 정보를 ContentsDetailImagePanel에 전달
 			FrameBase.getInstance().setInnerPanel(new ContentsDetailImagePanel(content), "mid");

--- a/src/main/java/Panel/RankingPagePanel.java
+++ b/src/main/java/Panel/RankingPagePanel.java
@@ -6,6 +6,7 @@ import DAO.FavoriteDAO;
 import Data.AppConstants;
 import Helper.GenericFinder;
 import Helper.ImageHelper;
+import Helper.SmoothLabel;
 import Managers.DBDataManagers;
 import Managers.DataManagers;
 import VO.FavoriteVO;
@@ -230,7 +231,7 @@ public class RankingPagePanel extends JPanel {
         rankingLabel.add(rankLabel);
 
         //썸네일 버튼
-        JButton thumbnailButton = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 79, 99,item.getId()));
+        JButton thumbnailButton = new JButton(ImageHelper.getResizedImageIconFromUrl(item.getThumbnail(), 79, 99,item.getId(), false, true));
         thumbnailButton.setBounds(50, 14, 79, 99);
         thumbnailButton.setBorderPainted(false);
         thumbnailButton.setContentAreaFilled(false);
@@ -251,10 +252,11 @@ public class RankingPagePanel extends JPanel {
      		}
         
         //장르 텍스트
-        JLabel genreText = new JLabel(genreTextlength, SwingConstants.CENTER);
+     	SmoothLabel genreText = new SmoothLabel(genreTextlength);
+     	genreText.setHorizontalAlignment(SwingConstants.CENTER);
         genreText.setBounds(0, 2, 80, 18);
         genreText.setForeground(Color.decode(AppConstants.UI_POINT_COLOR_HEX));
-        genreText.setFont(DataManagers.getInstance().getFont("bold", 6));
+        genreText.setFont(DataManagers.getInstance().getFont("bold", 7));
         categoryLabel.add(genreText);
 
         //타이틀

--- a/src/main/java/Panel/SearchMainPanel.java
+++ b/src/main/java/Panel/SearchMainPanel.java
@@ -3,6 +3,7 @@ package Panel;
 import Data.AppConstants;
 import Data.EachContentData;
 import Helper.ImageHelper;
+import Helper.SmoothLabel;
 import Managers.DBDataManagers;
 import Managers.DataManagers;
 import Component.CustomButton;
@@ -152,6 +153,7 @@ public class SearchMainPanel extends JPanel {
                 //검색 기능 호출
                 System.out.println(searchField.getText());
                 EditResultText(String.format("'%s'에 대한 검색 결과", searchField.getText()), searchedText);
+                bottomPanel.add(searchedText); // 다시 추가 (상단 텍스트 유지)
                 SearchItems(searchField.getText());
             }
 
@@ -173,16 +175,16 @@ public class SearchMainPanel extends JPanel {
     }
 
     private void SearchItems(String searchText) {
+    	
+    	//기존 컴포넌트 모두 제거 (중첩 방지)
+    	clearBottomPanel();
+        
         //검색 페이지로 넘기기
         List<ItemVO> findList= new ArrayList<>();
         findList = DataManagers.getInstance().getSearchItemKeyword(searchText);
         for (ItemVO itemVO : findList) {
             System.out.println(itemVO.getTitle());
         }
-
-        bottomPanel.remove(itemBG);
-        bottomPanel.remove(itemPanel);
-        bottomPanel.remove(scrollPane);
 
         itemPanel.setOpaque(false);
         itemPanel.setBackground(new Color(0, 0, 0, 0)); // 🔥 완전 투명 배경 설정
@@ -207,7 +209,7 @@ public class SearchMainPanel extends JPanel {
                 new Rectangle(128,23,47,17)
         );
 
-        bottomPanel.add(setScrollLayoutNull(itemPanel, eachContentData, findList,510,126, findList.size(), 1,10,10,10,true));
+        //bottomPanel.add(setScrollLayoutNull(itemPanel, eachContentData, findList,510,126, findList.size(), 1,10,10,10,true));
 
         if(findList.isEmpty()){
             JLabel noResultText =new JLabel(String.format("'%s'에 대한 검색 결과가 없습니다!", searchText));
@@ -215,11 +217,21 @@ public class SearchMainPanel extends JPanel {
             noResultText.setForeground(Color.decode(AppConstants.UI_BACKGROUND_HEX));
             noResultText.setBounds(165,140,536,200);
             bottomPanel.add(noResultText);
+        } else {
+            // 결과 있을 때만 아이템 리스트 추가
+            bottomPanel.add(setScrollLayoutNull(itemPanel, eachContentData, findList, 510, 126, findList.size(), 1, 10, 10, 10, true));
         }
 
         bottomPanel.add(itemBG);
     }
-
+    
+    // 검색 전 초기화
+    private void clearBottomPanel() {
+        bottomPanel.removeAll();
+        bottomPanel.revalidate();
+        bottomPanel.repaint();
+    }
+    
     private JLabel SetResultText(String searchText) {
         JLabel recommendText = new JLabel(searchText);
         recommendText.setBounds(31,12,434,28);
@@ -302,7 +314,7 @@ public class SearchMainPanel extends JPanel {
         }
 
         //장르 세팅
-        JLabel genreText = new JLabel(genresText, SwingConstants.CENTER);
+        SmoothLabel genreText = new SmoothLabel(genresText);
         genreText.setHorizontalAlignment(SwingConstants.CENTER);
         genreText.setBorder(null);
         genreText.setBounds(eachContentData.getCategoryTextRect().x,eachContentData.getCategoryTextRect().y, itemLabel.getWidth(), eachContentData.getCategoryTextRect().height);
@@ -426,7 +438,7 @@ public class SearchMainPanel extends JPanel {
             lastItemY = y + perHeight; // 🔥 마지막 Y값 업데이트
             ItemVO itemVO = items.get(i);
 
-            data.setThumbImage(ImageHelper.getResizedImageIconFromUrl(itemVO.getThumbnail(), data.getThumbRect().width, data.getThumbRect().height, itemVO.getId()));
+            data.setThumbImage(ImageHelper.getResizedImageIconFromUrl(itemVO.getThumbnail(), data.getThumbRect().width, data.getThumbRect().height, itemVO.getId(), false, true));
             JLabel item = createItem(itemVO, data, isRowOnly);
             item.setOpaque(false);
             item.setBounds(isRowOnly ? 0 : x, y, perWidth, perHeight);
@@ -436,7 +448,7 @@ public class SearchMainPanel extends JPanel {
         // 🚀 패널 크기 강제 설정 (세로 크기 고려)
         int panelWidth = isRowOnly ? lastItemX + padding : 536; // 🔥 고정된 너비 사용
         int panelHeight = lastItemY + padding; // 🔥 아이템 끝 + 여유 공간 추가
-        itemPanel.setPreferredSize(new Dimension(panelWidth, (panelHeight - 20))); // **스크롤 가능하도록 설정**
+        itemPanel.setPreferredSize(new Dimension(panelWidth, (panelHeight - 10))); // **스크롤 가능하도록 설정**
 
         // 🚀 **스크롤 패널 설정**
         scrollPane = new JScrollPane(itemPanel);


### PR DESCRIPTION
ContentsDetailImagePanel
contents 디테일 엑터 빈배열 예외처리
안하면 오류터짐 페이지 접근 불가

serchpage
검색결과 2번 이상 없을때 결과 없음 텍스트 겹치는 문제 해결
최초 디폴트 보여지는 컨텐츠 12개로 수정  하단 공백 매꾸기
스크롤 범위 이슈로 맨끝에 좀 짤리는거 수정
중첩방지 메소드 추가

openpage
이미지,아이콘 캐시 초기화 걸어서 이미지 헬퍼 정상 적용되도록함
중복 컨텐츠가 있을때 핼퍼를 거치지 않는 오류 수정

contentDAO
랜덤 컨텐츠 중복되면 빈공간 형성하는 오류 수정

DataManagers
 private Map<Integer, ImageIcon> tempThumbnail = new HashMap<>();
-> String으로 변환
String으로 이미지 핼퍼 사용 시 key를 복합화를 위해 전환함
Integer  덮어쓰기 문제 발생
같은 ID의 이미지라도 사이즈, 라운드 형태, 상황이 다를 때 구분하고 각각 캐싱하기 위해서

MainPagePanel
small패널 내부 컨텐츠가 빅컨텐츠의 컨텐츠를 중복으로 가져와서 중복 시 핼퍼가 먹지 않는 상황 발생 이걸 피하기 위한 코드 추가

이미지 스케일링 외부 유틸사용방식 수정
더 선명해짐